### PR TITLE
Fix postfix projected secret volume rendering

### DIFF
--- a/charts/postfix/Chart.yaml
+++ b/charts/postfix/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: postfix
 description: Postfix SMTP relay with optional saslauthd sidecar
 type: application
-version: 0.2.1
+version: 0.2.2
 # renovate: image=ghcr.io/joejulian/container-images/postfix
 appVersion: "3.11.1"
 home: https://github.com/joejulian/charts/tree/master/charts/postfix

--- a/charts/postfix/templates/statefulset.yaml
+++ b/charts/postfix/templates/statefulset.yaml
@@ -125,10 +125,10 @@ spec:
 {{- end }}
 {{- if .Values.config.secretData }}
               - secret:
-                  secretName: {{ include "postfix.configSecretName" . }}
+                  name: {{ include "postfix.configSecretName" . }}
 {{- else if .Values.config.existingConfigSecret }}
               - secret:
-                  secretName: {{ .Values.config.existingConfigSecret }}
+                  name: {{ .Values.config.existingConfigSecret }}
 {{- end }}
 {{- if .Values.tls.enabled }}
         - name: postfix-certs


### PR DESCRIPTION
## Summary
- fix projected secret sources in the postfix StatefulSet template to use the Kubernetes  field
- bump the postfix chart version to 

## Why
 renders an invalid projected volume source (), which causes Flux Helm upgrades in picluster to fail.
