### PR TITLE
Add luanti chart and deprecate minetest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Consolidated Helm chart monorepo for the charts maintained under the `joejulian`
 
 - `home-assistant`
 - `justmount`
+- `luanti`
 - `minetest`
 - `mosquitto`
 - `nzbget`
@@ -13,6 +14,10 @@ Consolidated Helm chart monorepo for the charts maintained under the `joejulian`
 - `openldap`
 - `postfix`
 - `sonarr`
+
+Deprecated:
+
+- `minetest` in favor of `luanti`
 
 ## Automation
 

--- a/charts/luanti/.helmignore
+++ b/charts/luanti/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/luanti/Chart.yaml
+++ b/charts/luanti/Chart.yaml
@@ -1,15 +1,14 @@
 annotations:
   org.opencontainers.image.source: https://github.com/joejulian/charts
 apiVersion: v1
-deprecated: true
-description: Deprecated chart retained for migration to luanti
-name: minetest
+description: A Helm chart for running a Luanti server
+name: luanti
 # renovate: image=ghcr.io/joejulian/container-images/minetest
 appVersion: "5.15.0-r1"
-home: https://github.com/joejulian/charts/tree/master/charts/minetest
+home: https://github.com/joejulian/charts/tree/main/charts/luanti
 maintainers:
   - name: Joe Julian
     email: me@joejulian.name
 sources:
-  - https://github.com/minetest/minetest
-version: 0.0.11
+  - https://github.com/luanti-org/luanti
+version: 0.0.1

--- a/charts/luanti/templates/NOTES.txt
+++ b/charts/luanti/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "luanti.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "luanti.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "luanti.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "luanti.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/charts/luanti/templates/_helpers.tpl
+++ b/charts/luanti/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "luanti.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "luanti.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/luanti/templates/configmap.yaml
+++ b/charts/luanti/templates/configmap.yaml
@@ -1,0 +1,13 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-conf
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}"
+data:
+  luanti.conf: |
+{{ .Values.luanti.config | indent 4 }}

--- a/charts/luanti/templates/deployment.yaml
+++ b/charts/luanti/templates/deployment.yaml
@@ -52,11 +52,23 @@ spec:
             - -c
             - |
               [ ! -d /data/worldmods ] || rm -rf /data/worldmods
+              mkdir -p /data/worldmods
+              tmp_root="$(mktemp -d)"
+              trap 'rm -rf "${tmp_root}"' EXIT
               while read mod url; do
                 [ -n "${mod}" ] || continue
                 echo "Installing from ${mod}"
-                mkdir -p "/data/worldmods/${mod}"
-                wget -O - -q "${url}" | tar -C "/data/worldmods/${mod}" --strip-components=1 -xz
+                mod_tmp="${tmp_root}/${mod}"
+                mkdir -p "${mod_tmp}"
+                wget -O - -q "${url}" | tar -C "${mod_tmp}" --strip-components=1 -xz
+                if [ -f "${mod_tmp}/modpack.conf" ]; then
+                  for entry in "${mod_tmp}"/*; do
+                    mv "${entry}" /data/worldmods/
+                  done
+                  rmdir "${mod_tmp}"
+                else
+                  mv "${mod_tmp}" "/data/worldmods/${mod}"
+                fi
               done < /config/installmods.txt
           volumeMounts:
             - name: data

--- a/charts/luanti/templates/deployment.yaml
+++ b/charts/luanti/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "luanti.fullname" . }}
+  labels:
+    app: {{ template "luanti.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ template "luanti.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "luanti.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: {{ .Chart.Name }}-game
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          command:
+            - sh
+            - -e
+            - -o
+            - pipefail
+            - -c
+            - |
+              mkdir -p "/games"
+              if [ ! -d "/games/{{ .Values.game.name }}" ]; then
+                mkdir -p "/games/{{ .Values.game.name }}"
+                wget -O - -q "{{ .Values.game.downloadURL }}" | tar -C "/games/{{ .Values.game.name }}" --strip-components=1 -xz
+              fi
+          volumeMounts:
+            - name: games
+              mountPath: /games
+{{- if .Values.mods.installmods }}
+        - name: {{ .Chart.Name }}-mods
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          command:
+            - sh
+            - -e
+            - -o
+            - pipefail
+            - -c
+            - |
+              [ ! -d /data/worldmods ] || rm -rf /data/worldmods
+              while read mod url; do
+                [ -n "${mod}" ] || continue
+                echo "Installing from ${mod}"
+                mkdir -p "/data/worldmods/${mod}"
+                wget -O - -q "${url}" | tar -C "/data/worldmods/${mod}" --strip-components=1 -xz
+              done < /config/installmods.txt
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: mods
+              mountPath: /config/installmods.txt
+              subPath: installmods.txt
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+{{ toYaml .Values.command | indent 12 }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+            - name: data
+              mountPath: /data
+            - name: games
+              mountPath: /root/.minetest/games
+{{- if .Values.world.existingSecret }}
+            - name: world-secret
+              mountPath: /data/world.mt
+              subPath: {{ .Values.world.secretKey }}
+{{- end }}
+          ports:
+            - name: dataport
+              containerPort: {{ .Values.service.internalPort }}
+              protocol: UDP
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - /proc/1/status
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Release.Name }}-conf
+        - name: data
+          persistentVolumeClaim:
+              claimName: {{ default (printf "%s-data" .Release.Name) .Values.persistence.existingClaim }}
+        - name: games
+          emptyDir: {}
+{{- if .Values.world.existingSecret }}
+        - name: world-secret
+          secret:
+            secretName: {{ .Values.world.existingSecret }}
+{{- end }}
+{{- if .Values.mods.installmods }}
+        - name: mods
+          configMap:
+            defaultMode: 420
+            name: {{ .Release.Name }}-mods
+{{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/charts/luanti/templates/deployment.yaml
+++ b/charts/luanti/templates/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.mods.installmods }}
+        checksum/mods: {{ include (print $.Template.BasePath "/mods-configmap.yaml") . | sha256sum }}
+{{- end }}
       labels:
         app: {{ template "luanti.name" . }}
         release: {{ .Release.Name }}
@@ -53,22 +58,11 @@ spec:
             - |
               [ ! -d /data/worldmods ] || rm -rf /data/worldmods
               mkdir -p /data/worldmods
-              tmp_root="$(mktemp -d)"
-              trap 'rm -rf "${tmp_root}"' EXIT
               while read mod url; do
                 [ -n "${mod}" ] || continue
                 echo "Installing from ${mod}"
-                mod_tmp="${tmp_root}/${mod}"
-                mkdir -p "${mod_tmp}"
-                wget -O - -q "${url}" | tar -C "${mod_tmp}" --strip-components=1 -xz
-                if [ -f "${mod_tmp}/modpack.conf" ]; then
-                  for entry in "${mod_tmp}"/*; do
-                    mv "${entry}" /data/worldmods/
-                  done
-                  rmdir "${mod_tmp}"
-                else
-                  mv "${mod_tmp}" "/data/worldmods/${mod}"
-                fi
+                mkdir -p "/data/worldmods/${mod}"
+                wget -O - -q "${url}" | tar -C "/data/worldmods/${mod}" --strip-components=1 -xz
               done < /config/installmods.txt
           volumeMounts:
             - name: data

--- a/charts/luanti/templates/ingress.yaml
+++ b/charts/luanti/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "luanti.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "luanti.fullname" . }}
+  labels:
+    app: {{ template "luanti.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/luanti/templates/mods-configmap.yaml
+++ b/charts/luanti/templates/mods-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.mods.installmods }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mods
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}"
+data:
+  installmods.txt: |
+{{ .Values.mods.installmods | indent 4 }}
+{{- end }}

--- a/charts/luanti/templates/pvc.yaml
+++ b/charts/luanti/templates/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi
+

--- a/charts/luanti/templates/service.yaml
+++ b/charts/luanti/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "luanti.fullname" . }}
+  labels:
+    app: {{ template "luanti.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: UDP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "luanti.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/luanti/templates/tests/test-readiness.yaml
+++ b/charts/luanti/templates/tests/test-readiness.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "luanti.fullname" . }}-test"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ template "luanti.fullname" . }}-test"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ template "luanti.fullname" . }}-test"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: "{{ template "luanti.fullname" . }}-test"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ template "luanti.fullname" . }}-test"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "luanti.fullname" . }}-test-readiness"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: "{{ template "luanti.fullname" . }}-test"
+  containers:
+    - name: kubectl
+      image: rancher/kubectl:v1.32.2
+      command: ["kubectl"]
+      args:
+        - rollout
+        - status
+        - deployment/{{ template "luanti.fullname" . }}
+        - -n
+        - {{ .Release.Namespace }}
+        - --timeout=180s
+  restartPolicy: Never

--- a/charts/luanti/values.yaml
+++ b/charts/luanti/values.yaml
@@ -1,0 +1,68 @@
+# Default values for luanti.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+luanti:
+  config: ""
+world:
+  existingSecret: ""
+  secretKey: world.mt
+mods:
+  installmods: ""
+game:
+  name: minetest_game
+  downloadURL: https://github.com/luanti-org/minetest_game/archive/refs/heads/master.tar.gz
+persistence:
+  existingClaim: ""
+replicaCount: 1
+image:
+  repository: ghcr.io/joejulian/container-images/minetest
+  tag: ""
+  pullPolicy: IfNotPresent
+initContainer:
+  image:
+    repository: alpine
+    # renovate: image=alpine
+    tag: 3.23.3
+    pullPolicy: IfNotPresent
+
+command:
+  - /usr/bin/luantiserver
+  - --server
+  - --config
+  - /config/luanti.conf
+  - --gameid
+  - minetest_game
+  - --world
+  - /data
+  - --logfile
+  - ""
+  - --verbose
+service:
+  name: luanti
+  type: NodePort
+  externalPort: 30000
+  internalPort: 30000
+ingress:
+  enabled: false
+  # Used to create an Ingress record.
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/charts/luanti/values.yaml
+++ b/charts/luanti/values.yaml
@@ -26,7 +26,7 @@ initContainer:
     pullPolicy: IfNotPresent
 
 command:
-  - /usr/games/minetest
+  - /usr/bin/minetest
   - --server
   - --config
   - /config/luanti.conf

--- a/charts/luanti/values.yaml
+++ b/charts/luanti/values.yaml
@@ -26,7 +26,7 @@ initContainer:
     pullPolicy: IfNotPresent
 
 command:
-  - /usr/bin/luantiserver
+  - /usr/games/minetest
   - --server
   - --config
   - /config/luanti.conf


### PR DESCRIPTION
Adds a new `luanti` chart, marks `minetest` deprecated, and updates the repo README so the cluster can migrate without keeping the old chart as the long-term source of truth.