### PR TITLE
Skip chart PVCs when existing claims are used

### DIFF
--- a/charts/luanti/Chart.yaml
+++ b/charts/luanti/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
     email: me@joejulian.name
 sources:
   - https://github.com/luanti-org/luanti
-version: 0.0.1
+version: 0.0.2

--- a/charts/luanti/templates/pvc.yaml
+++ b/charts/luanti/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistence.existingClaim }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -8,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 3Gi
-
+{{- end }}

--- a/charts/minetest/Chart.yaml
+++ b/charts/minetest/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
     email: me@joejulian.name
 sources:
   - https://github.com/minetest/minetest
-version: 0.0.11
+version: 0.0.12

--- a/charts/minetest/templates/pvc.yaml
+++ b/charts/minetest/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistence.existingClaim }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -8,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 3Gi
-
+{{- end }}


### PR DESCRIPTION
## Summary
- do not render PVC resources when `persistence.existingClaim` is set
- bump the luanti and minetest chart versions for release

## Testing
- helm lint charts/luanti
- helm lint charts/minetest