### PR TITLE
Handle installmods files without trailing newlines

### DIFF
--- a/charts/luanti/Chart.yaml
+++ b/charts/luanti/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
     email: me@joejulian.name
 sources:
   - https://github.com/luanti-org/luanti
-version: 0.0.2
+version: 0.0.3

--- a/charts/luanti/templates/deployment.yaml
+++ b/charts/luanti/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - |
               [ ! -d /data/worldmods ] || rm -rf /data/worldmods
               mkdir -p /data/worldmods
-              while read mod url; do
+              while read mod url || [ -n "${mod}" ]; do
                 [ -n "${mod}" ] || continue
                 echo "Installing from ${mod}"
                 mkdir -p "/data/worldmods/${mod}"

--- a/charts/minetest/Chart.yaml
+++ b/charts/minetest/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
     email: me@joejulian.name
 sources:
   - https://github.com/minetest/minetest
-version: 0.0.12
+version: 0.0.13

--- a/charts/minetest/templates/deployment.yaml
+++ b/charts/minetest/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - -c
             - |
               [ ! -d /data/worldmods ] || rm -rf /data/worldmods
-              while read mod url; do
+              while read mod url || [ -n "${mod}" ]; do
                 [ -n "${mod}" ] || continue
                 echo "Installing from ${mod}"
                 mkdir -p "/data/worldmods/${mod}"


### PR DESCRIPTION
## Summary
- make the mod bootstrap loop process the final entry even when `installmods.txt` has no trailing newline
- bump the luanti and minetest chart versions for release

## Testing
- helm lint charts/luanti
- helm lint charts/minetest