### PR TITLE
Fix Luanti image defaults

### DIFF
--- a/charts/luanti/Chart.yaml
+++ b/charts/luanti/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
 apiVersion: v1
 description: A Helm chart for running a Luanti server
 name: luanti
-# renovate: image=ghcr.io/joejulian/container-images/minetest
+# renovate: image=ghcr.io/joejulian/container-images/luanti
 appVersion: "5.15.0-r1"
 home: https://github.com/joejulian/charts/tree/main/charts/luanti
 maintainers:
@@ -11,4 +11,4 @@ maintainers:
     email: me@joejulian.name
 sources:
   - https://github.com/luanti-org/luanti
-version: 0.0.3
+version: 0.0.4

--- a/charts/luanti/templates/deployment.yaml
+++ b/charts/luanti/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       initContainers:
         - name: {{ .Chart.Name }}-game
-          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          image: "{{ .Values.initContainer.image.repository }}:{{ default .Chart.AppVersion .Values.initContainer.image.tag }}"
           imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           command:
             - sh
@@ -47,7 +47,7 @@ spec:
               mountPath: /games
 {{- if .Values.mods.installmods }}
         - name: {{ .Chart.Name }}-mods
-          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          image: "{{ .Values.initContainer.image.repository }}:{{ default .Chart.AppVersion .Values.initContainer.image.tag }}"
           imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           command:
             - sh

--- a/charts/luanti/values.yaml
+++ b/charts/luanti/values.yaml
@@ -26,7 +26,6 @@ initContainer:
 
 command:
   - /usr/bin/luantiserver
-  - --server
   - --config
   - /config/luanti.conf
   - --gameid

--- a/charts/luanti/values.yaml
+++ b/charts/luanti/values.yaml
@@ -15,18 +15,17 @@ persistence:
   existingClaim: ""
 replicaCount: 1
 image:
-  repository: ghcr.io/joejulian/container-images/minetest
+  repository: ghcr.io/joejulian/container-images/luanti
   tag: ""
   pullPolicy: IfNotPresent
 initContainer:
   image:
-    repository: alpine
-    # renovate: image=alpine
-    tag: 3.23.3
+    repository: ghcr.io/joejulian/container-images/luanti
+    tag: ""
     pullPolicy: IfNotPresent
 
 command:
-  - /usr/bin/minetest
+  - /usr/bin/luantiserver
   - --server
   - --config
   - /config/luanti.conf


### PR DESCRIPTION
## Summary
- switch the Luanti chart defaults to the dedicated Luanti image
- use the server-capable image for init containers by default
- invoke luantiserver directly and default init image tags to chart appVersion

## Testing
- helm lint charts/luanti
- ./scripts/build-local.sh images/luanti (in container-images repo)