### PR TITLE
Update Plex chart

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -4,9 +4,9 @@ apiVersion: v2
 name: plex
 description: Plex Media Server chart with GPU, certificate, ingress, and LB options
 type: application
-version: 0.2.0
+version: 0.2.1
 # renovate: image=ghcr.io/joejulian/container-images/plex-media-server-plexpass
-appVersion: "1.43.1.10561-1"
+appVersion: "1.43.2.10687-1"
 home: https://github.com/joejulian/charts/tree/main/charts/plex
 maintainers:
   - name: Joe Julian


### PR DESCRIPTION
## Summary
- bump plex chart to 0.2.1
- update appVersion to the newly published plex-media-server-plexpass image 1.43.2.10687-1

## Validation
- helm lint charts/plex -f ci/values/plex.yaml
- helm template plex charts/plex -f ci/values/plex.yaml
- bash ./scripts/check-chart-version-bumps.sh origin/main HEAD