### PR TITLE
Align Sonarr chart version

### DIFF
--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/home-operations/containers
 - https://github.com/pree/helm-charts
 type: application
-version: 0.0.3
+version: 1.12.0


### PR DESCRIPTION
## Summary
- change the Sonarr chart version from 0.0.3 to 1.12.0 so Flux version constraints and future chart updates line up with the migrated upstream chart series
- keep appVersion at 4.0.17.2969

## Validation
- helm dependency build charts/sonarr
- helm lint charts/sonarr -f ci/values/sonarr.yaml
- helm template sonarr charts/sonarr -f ci/values/sonarr.yaml
- bash ./scripts/check-chart-version-bumps.sh origin/main HEAD