### PR TITLE
fix(cyrus-imap): guard the ephemeral socket mount

### DIFF
--- a/charts/cyrus-imap/Chart.yaml
+++ b/charts/cyrus-imap/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: cyrus-imap
 description: Cyrus IMAP server with optional saslauthd sidecar and TLS assets
 type: application
-version: "0.1.4"
+version: "0.1.5"
 # renovate: image=ghcr.io/joejulian/container-images/cyrus-imap
 appVersion: "3.12.2"
 home: https://github.com/joejulian/charts/tree/main/charts/cyrus-imap

--- a/charts/cyrus-imap/templates/deployment.yaml
+++ b/charts/cyrus-imap/templates/deployment.yaml
@@ -68,10 +68,30 @@ spec:
             - name: sieve
               containerPort: 4190
           livenessProbe:
+            {{- if .Values.mainContainer.mountGuard.enabled }}
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - |-
+                  /usr/sbin/mountpoint -q /data/imap_db/socket
+                  /usr/sbin/ss -H -lnt "sport = :143" | /usr/bin/grep -q .
+            {{- else }}
             tcpSocket:
               port: imap
+            {{- end }}
             initialDelaySeconds: 90
             periodSeconds: 10
+          {{- if .Values.mainContainer.mountGuard.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - /usr/sbin/mountpoint
+                - -q
+                - /data/imap_db/socket
+            periodSeconds: 5
+            failureThreshold: 3
+          {{- end }}
           readinessProbe:
             tcpSocket:
               port: imap

--- a/charts/cyrus-imap/values.yaml
+++ b/charts/cyrus-imap/values.yaml
@@ -76,6 +76,8 @@ mainContainer:
   args:
     - -command
     - /usr/lib/cyrus/master -C /config/imapd.conf -M /config/cyrus.conf
+  mountGuard:
+    enabled: true
 
 initContainer:
   enabled: true

--- a/scripts/test-charts.sh
+++ b/scripts/test-charts.sh
@@ -37,6 +37,24 @@ assert_cyrus_imap_ready() {
   return 1
 }
 
+assert_cyrus_imap_mount_guard() {
+  local namespace="$1"
+  local pod
+
+  pod="$(kubectl -n "${namespace}" get pods \
+    -l app.kubernetes.io/name=cyrus-imap \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}')"
+  if [[ -z "${pod}" ]]; then
+    echo "cyrus-imap has no running pod in namespace ${namespace}" >&2
+    return 1
+  fi
+
+  kubectl -n "${namespace}" exec "${pod}" -c cyrus-imap -- \
+    /bin/sh -ec '/usr/sbin/mountpoint -q /data/imap_db/socket
+/usr/sbin/ss -H -lnt "sport = :143" | /usr/bin/grep -q .'
+}
+
 run_chart_tests() {
   local chart_name="$1"
   local release_name="$2"
@@ -45,6 +63,7 @@ run_chart_tests() {
   case "${chart_name}" in
     cyrus-imap)
       assert_cyrus_imap_ready "${namespace}"
+      assert_cyrus_imap_mount_guard "${namespace}"
       ;;
     *)
       helm test "${release_name}" -n "${namespace}" --timeout 5m


### PR DESCRIPTION
The Cyrus accept-lock files must stay on the nested `emptyDir` mounted at `/data/imap_db/socket`. If that mount disappears from the container namespace, Cyrus silently writes its blocking accept locks to the persistent data filesystem instead.

This adds startup and liveness checks for the nested mount, preserves the existing IMAP listener check, and exercises the guard during chart install/upgrade CI.

Validation:
- `helm lint charts/cyrus-imap`
- enabled and disabled `helm template` renders
- `bash -n scripts/test-charts.sh`