### PR TITLE
fix(cyrus-imap): clear replaced probe handlers

### DIFF
--- a/charts/cyrus-imap/Chart.yaml
+++ b/charts/cyrus-imap/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: cyrus-imap
 description: Cyrus IMAP server with optional saslauthd sidecar and TLS assets
 type: application
-version: "0.1.5"
+version: "0.1.6"
 # renovate: image=ghcr.io/joejulian/container-images/cyrus-imap
 appVersion: "3.12.2"
 home: https://github.com/joejulian/charts/tree/main/charts/cyrus-imap

--- a/charts/cyrus-imap/templates/deployment.yaml
+++ b/charts/cyrus-imap/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
               containerPort: 4190
           livenessProbe:
             {{- if .Values.mainContainer.mountGuard.enabled }}
+            tcpSocket: null
             exec:
               command:
                 - /bin/sh
@@ -77,6 +78,7 @@ spec:
                   /usr/sbin/mountpoint -q /data/imap_db/socket
                   /usr/sbin/ss -H -lnt "sport = :143" | /usr/bin/grep -q .
             {{- else }}
+            exec: null
             tcpSocket:
               port: imap
             {{- end }}

--- a/scripts/test-charts.sh
+++ b/scripts/test-charts.sh
@@ -126,6 +126,7 @@ test_chart() {
   local release_name
   local values_file
   local -a helm_args
+  local -a previous_helm_args
 
   chart_name="$(basename "${chart_dir}")"
   namespace="ci-${chart_name}"
@@ -146,6 +147,16 @@ test_chart() {
   kubectl get namespace "${namespace}" >/dev/null 2>&1 || kubectl create namespace "${namespace}"
   setup_image_pull_secret "${namespace}"
   setup_chart_fixtures "${chart_name}" "${namespace}"
+
+  if [[ "${chart_name}" == "cyrus-imap" ]]; then
+    previous_helm_args=(upgrade --install "${release_name}" \
+      oci://ghcr.io/joejulian/charts/cyrus-imap \
+      --version 0.1.4 -n "${namespace}" --wait --timeout 10m)
+    if [[ -f "${values_file}" ]]; then
+      previous_helm_args+=(-f "${values_file}")
+    fi
+    helm "${previous_helm_args[@]}"
+  fi
 
   helm "${helm_args[@]}"
   wait_for_workloads "${namespace}"


### PR DESCRIPTION
Flux uses server-side apply for Helm upgrades. When 0.1.5 changed the liveness handler from `tcpSocket` to `exec`, the old handler remained and Kubernetes rejected the Deployment because a probe may have only one handler.

This explicitly clears the superseded handler in both modes and makes Cyrus CI install 0.1.4 before upgrading to the candidate chart, covering the real migration.

Validation:
- `helm lint charts/cyrus-imap`
- enabled/disabled client-side Kubernetes dry runs
- server-side dry-run against the existing Deployment leaves only the exec handler
- `bash -n scripts/test-charts.sh`