### PR TITLE
fix(cyrus-imap): supervise the socket mount

### DIFF
--- a/charts/cyrus-imap/Chart.yaml
+++ b/charts/cyrus-imap/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: cyrus-imap
 description: Cyrus IMAP server with optional saslauthd sidecar and TLS assets
 type: application
-version: "0.1.6"
+version: "0.1.7"
 # renovate: image=ghcr.io/joejulian/container-images/cyrus-imap
 appVersion: "3.12.2"
 home: https://github.com/joejulian/charts/tree/main/charts/cyrus-imap

--- a/charts/cyrus-imap/templates/configmap.yaml
+++ b/charts/cyrus-imap/templates/configmap.yaml
@@ -9,3 +9,31 @@ data:
 {{ .Values.config.cyrusConf | indent 4 }}
   imapd.conf: |
 {{ .Values.config.imapdConf | indent 4 }}
+  {{- if .Values.mainContainer.mountGuard.enabled }}
+  mount-guard.sh: |
+    #!/bin/sh
+    set -u
+
+    "$@" &
+    child_pid=$!
+
+    terminate() {
+      trap - INT TERM
+      kill -TERM "${child_pid}" 2>/dev/null || true
+      wait "${child_pid}"
+      exit $?
+    }
+    trap terminate INT TERM
+
+    while kill -0 "${child_pid}" 2>/dev/null; do
+      if ! /usr/sbin/mountpoint -q /data/imap_db/socket; then
+        echo "/data/imap_db/socket is no longer a mountpoint; terminating Cyrus" >&2
+        kill -TERM "${child_pid}" 2>/dev/null || true
+        wait "${child_pid}"
+        exit 1
+      fi
+      sleep 10
+    done
+
+    wait "${child_pid}"
+  {{- end }}

--- a/charts/cyrus-imap/templates/deployment.yaml
+++ b/charts/cyrus-imap/templates/deployment.yaml
@@ -46,11 +46,19 @@ spec:
         - name: cyrus-imap
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.mainContainer.mountGuard.enabled }}
+          command:
+            - /bin/sh
+            - /config/mount-guard.sh
+          args:
+            {{- concat .Values.mainContainer.command (default (list) .Values.mainContainer.args) | toYaml | nindent 12 }}
+          {{- else }}
           command:
             {{- toYaml .Values.mainContainer.command | nindent 12 }}
           {{- with .Values.mainContainer.args }}
           args:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -68,20 +76,8 @@ spec:
             - name: sieve
               containerPort: 4190
           livenessProbe:
-            {{- if .Values.mainContainer.mountGuard.enabled }}
-            tcpSocket: null
-            exec:
-              command:
-                - /bin/sh
-                - -ec
-                - |-
-                  /usr/sbin/mountpoint -q /data/imap_db/socket
-                  /usr/sbin/ss -H -lnt "sport = :143" | /usr/bin/grep -q .
-            {{- else }}
-            exec: null
             tcpSocket:
               port: imap
-            {{- end }}
             initialDelaySeconds: 90
             periodSeconds: 10
           {{- if .Values.mainContainer.mountGuard.enabled }}

--- a/scripts/test-charts.sh
+++ b/scripts/test-charts.sh
@@ -23,9 +23,8 @@ wait_for_workloads() {
 assert_cyrus_imap_ready() {
   local namespace="$1"
   local endpoint_ip=""
-  local attempt
 
-  for attempt in $(seq 1 30); do
+  for _ in {1..30}; do
     endpoint_ip="$(kubectl -n "${namespace}" get endpoints cyrus-imap -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)"
     if [[ -n "${endpoint_ip}" ]]; then
       return 0
@@ -44,7 +43,8 @@ assert_cyrus_imap_mount_guard() {
   pod="$(kubectl -n "${namespace}" get pods \
     -l app.kubernetes.io/name=cyrus-imap \
     --field-selector=status.phase=Running \
-    -o jsonpath='{.items[0].metadata.name}')"
+    --sort-by=.metadata.creationTimestamp \
+    -o name | tail -n 1)"
   if [[ -z "${pod}" ]]; then
     echo "cyrus-imap has no running pod in namespace ${namespace}" >&2
     return 1


### PR DESCRIPTION
Flux server-side apply cannot migrate a Kubernetes Probe between handler types because typed decoding drops null fields before the old handler is removed. Versions 0.1.5 and 0.1.6 therefore leave existing releases running safely on their prior Deployment but cannot upgrade them.

This keeps the existing TCP liveness handler and runs Cyrus under a small mount watchdog instead. The watchdog continuously verifies `/data/imap_db/socket` is a mountpoint and terminates Cyrus if it disappears, causing the normal container restart. The startup probe still prevents startup without the mount.

Validation:
- chart CI upgrades from released 0.1.4 before testing the candidate
- `helm lint` and enabled/disabled Kubernetes client dry-runs
- enabled wrapper exits successfully with a nested bind mount
- enabled wrapper detects an absent mount, terminates its child, and exits non-zero
- disabled render retains the original command and contains no watchdog